### PR TITLE
project pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             echo $TF_CLOUD_TOKEN | base64 -d > $HOME/.terraformrc
             echo $GOOGLE_CLOUD_KEYS | base64 -d > $HOME/gcloud_keys
             gcloud auth activate-service-account --key-file ${HOME}/gcloud_keys
-            gcloud container clusters get-credentials $CLUSTER_NAME --zone="us-east1-d"
+            gcloud container clusters get-credentials $CLUSTER_NAME --zone="us-east1-d" --project cicd-workshops
             cd part03/iac_kubernetes_app
             terraform init
             terraform plan -var $DOCKER_IMAGE -out=plan.txt
@@ -95,7 +95,7 @@ jobs:
             gcloud auth activate-service-account --key-file ${HOME}/gcloud_keys
             cd part03/iac_kubernetes_app
             terraform init
-            gcloud container clusters get-credentials $CLUSTER_NAME --zone="us-east1-d"            
+            gcloud container clusters get-credentials $CLUSTER_NAME --zone="us-east1-d" --project cicd-workshops          
             terraform destroy -var $DOCKER_IMAGE --auto-approve
             cd ../iac_gke_cluster/
             terraform init


### PR DESCRIPTION
When I was trying to simulate this Pipeline I always was receiving the error 403 when trying to issue this command from the CircleCI:

     gcloud container clusters get-credentials $CLUSTER_NAME --zone="us-east1-d" 

The way that I found to solve this issue is adding the project parameter, as below:

     gcloud container clusters get-credentials $CLUSTER_NAME --zone="us-east1-d" --project cicd-workshops